### PR TITLE
es_install_oss variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,8 +1,8 @@
 ---
 # Commons parameters for all ELK Stack
 es_major_version: "6.x"
-es_version: "6.4.2"
-es_enable_xpack: false
+es_version: "6.5.1"
+es_install_oss: false
 es_use_repository: true
 es_apt_key: "https://artifacts.elastic.co/GPG-KEY-elasticsearch"
 es_apt_url: "deb https://artifacts.elastic.co/packages/{{ es_repo_name }}/apt stable main"

--- a/tasks/compatibility-variables.yml
+++ b/tasks/compatibility-variables.yml
@@ -1,19 +1,11 @@
 ---
 - name: Set the defaults here otherwise they can't be overriden in the same play if the role is called twice
   set_fact:
-    es_open_xpack: true
-    es_install_xpack: false
     es_repo_name: "{{ es_major_version }}"
 
-- name: Detect if es_version is before X-Pack was open and included
-  set_fact:
-    es_open_xpack: false
-  when: "es_version | version_compare('6.3.0', '<')"
-
-- name: Use the oss repo and package if xpack is not being used
+- name: Use the oss repo and package if requested
   set_fact:
     es_repo_name: "{{ 'oss-' + es_major_version }}"
     kibana_package_name: "kibana-oss"
   when:
-    - es_open_xpack
-    - not es_enable_xpack
+    - es_install_oss

--- a/tasks/kibana-Debian.yml
+++ b/tasks/kibana-Debian.yml
@@ -24,31 +24,39 @@
     - { repo: "{{ es_apt_url }}", state: "present" }
   when: es_use_repository
 
-- name: Gracefully stop and remove kibana if we are switching to the oss version
+- name: Discover "inverse" package name step 1
+  set_fact: kibana_inverted_package_name='kibana'
   when:
     - kibana_package_name == 'kibana-oss'
+
+- name: Discover "inverse" package name step 2
+  set_fact: kibana_inverted_package_name='kibana-oss'
+  when:
+    - kibana_package_name == 'kibana'
+
+- name: Gracefully stop and remove kibana if we are switching to the oss version.
   block:
-  - name: Check if the kibana package is installed
-    shell: dpkg-query -W -f'${Status}' kibana
-    register: kibana_package
+  - name: Check if other package is installed
+    shell: dpkg-query -W -f'${Status}' {{ kibana_inverted_package_name }}
+    register: kibana_inverted_package
     failed_when: False
     changed_when: False
 
-  - name: stop kibana
+  - name: Debian - stop {{ kibana_inverted_package_name }}
     become: yes
     service:
       name: '{{ instance_init_script | basename }}'
       state: stopped
-    when: kibana_package.stdout == 'install ok installed'
+    when: kibana_inverted_package.stdout == 'install ok installed'
 
-  - name: Debian - Remove kibana package if we are installing the oss package
+  - name: Debian - remove {{ kibana_inverted_package_name }}
     become: yes
     apt:
-      name: 'kibana'
+      name: "{{ kibana_inverted_package_name }}"
       state: absent
-    when: kibana_package.stdout == 'install ok installed'
+    when: kibana_inverted_package.stdout == 'install ok installed'
 
-- name: Debian - Ensure kibana is installed
+- name: Debian - Ensure {{ kibana_package_name }} is installed
   become: yes
   apt:
     name: '{{ kibana_package_name }}{% if es_version is defined and es_version != "" %}={{ es_version }}{% endif %}'

--- a/tasks/kibana-parameters.yml
+++ b/tasks/kibana-parameters.yml
@@ -1,10 +1,6 @@
 ---
 # Check for mandatory parameters
 
-- name: fail when es_enable_xpack is true
-  fail: msg="this role doesn't manage xpack, it can install only oss version"
-  when: es_enable_xpack
-
 - name: fail when es_proxy_port is not defined or is blank
   fail: msg="es_proxy_port must be specified and cannot be blank when es_proxy_host is defined"
   when: (es_proxy_port is not defined or es_proxy_port == '') and (es_proxy_host is defined and es_proxy_host != '')

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -3,6 +3,7 @@
   hosts: all
   roles:
       - {role: elasticsearch, es_instance_name: "{{ inventory_hostname }}",
+         es_enable_xpack: false,
          es_config: {
              node.name: "{{ inventory_hostname }}",
              cluster.name: "elasticsearch_test",
@@ -14,6 +15,7 @@
          }
       }
       - {role: kibana,
+         es_install_oss: false,
          kibana_config: {
              server.name: "{{ inventory_hostname }}",
              server.port: 5601,
@@ -22,12 +24,11 @@
          }
       }
   vars:
-      es_version: "6.3.2"
+      es_version: "6.5.1"
       es_scripts: false
       es_templates: false
       es_version_lock: false
       es_heap_size: 1g
       es_api_host: localhost
       es_api_port: 9200
-      es_enable_xpack: false
       kibana_api_host: "localhost"


### PR DESCRIPTION
Hi Fedele,
Thanks for creating the ansible role!  
So, the standard version of Kibana has a number of interesting features which aren't available in the OSS version. 
"this role doesn't manage xpack, it can install only oss version".  
Only oss version... It seems like it would be preferable to install regular Kibana, unless oss is requested, and be able to support both.
- Toggle based on this variable:
es_install_oss: false
- Remove all mentions of xpack since that's not being managed.
- refer to the changes in this pull request, let me know what you think.
