### PR TITLE
change to version for Ansible >= 2.5

### DIFF
--- a/tasks/kibana-parameters.yml
+++ b/tasks/kibana-parameters.yml
@@ -24,11 +24,11 @@
   set_fact:
     use_system_d: >
       "{{ (ansible_distribution == 'Debian' and
-      ansible_distribution_version | version_compare('8', '>='))
+      ansible_distribution_version is version('8', '>='))
       or (ansible_distribution in ['RedHat','CentOS']
-      and ansible_distribution_version | version_compare('7', '>='))
+      and ansible_distribution_version is version('7', '>='))
       or (ansible_distribution == 'Ubuntu'
-      and ansible_distribution_version | version_compare('15', '>=')) }}"
+      and ansible_distribution_version is version('15', '>=')) }}"
 
 - name: set fact instance_sysd_script
   set_fact: instance_sysd_script={{ sysd_script }}


### PR DESCRIPTION
A potential fix for #6 . 

``version_compare`` is depricated from 2.5. Change to ``version``. 