### PR TITLE
fix empty space in version lock

### DIFF
--- a/tasks/kibana-RedHat-version-lock.yml
+++ b/tasks/kibana-RedHat-version-lock.yml
@@ -15,4 +15,4 @@
   shell: >
     yum versionlock delete 0:kibana*;
     yum versionlock add {{ kibana_package_name }}
-    {% if es_version is defined and es_version %}-{{ es_version }}{% endif %}
+    {%- if es_version is defined and es_version %}-{{ es_version }}{% endif %}


### PR DESCRIPTION
jinja2 if clause in next line on kibana-RedHat-version-lock.yml causes the version lock command to produce an additional empty space, which breaks the version lock command.