### PR TITLE
Ensure fact use_system_d can be filtered as a bool

### DIFF
--- a/tasks/kibana-parameters.yml
+++ b/tasks/kibana-parameters.yml
@@ -29,13 +29,9 @@
 
 - name: set fact use_system_d
   set_fact:
-    use_system_d: >
-      "{{ (ansible_distribution == 'Debian' and
-      ansible_distribution_version is version('8', '>='))
-      or (ansible_distribution in ['RedHat','CentOS']
-      and ansible_distribution_version is version('7', '>='))
-      or (ansible_distribution == 'Ubuntu'
-      and ansible_distribution_version is version('15', '>=')) }}"
+    use_system_d: "{{ (ansible_distribution == 'Debian' and ansible_distribution_version is version('8', '>='))
+          or (ansible_distribution in ['RedHat','CentOS'] and ansible_distribution_version is version('7', '>='))
+          or (ansible_distribution == 'Ubuntu' and ansible_distribution_version is version('15', '>=')) }}"
 
 - name: set fact instance_sysd_script
   set_fact: instance_sysd_script={{ sysd_script }}


### PR DESCRIPTION
When running this value wasn't being evaluated as a boolean true in 2.9


```
TASK [fedelemantuano.kibana : set fact use_system_d] **************************************************************************************************************************************************************************
task path: /redacted/roles/fedelemantuano.kibana/tasks/kibana-parameters.yml:30
ok: [redacted] => {
    "ansible_facts": {
        "use_system_d": "\"True\"\n"
    },
    "changed": false
}
```